### PR TITLE
Remove Pro upgrade lines

### DIFF
--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "سيتم قطع الاتصال تلقائيًا إذا تم تجاوز المهلة."),
         ("Connection failed due to inactivity", "فشل الاتصال بسبب عدم النشاط"),
         ("Check for software update on startup", "البحث عن تحديثات البرنامج عند بدء التشغيل"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "ترقية خادم VNFap Pro إلى {}"),
         ("pull_group_failed_tip", "فشل سحب المجموعة"),
         ("Filter by intersection", "تصفية حسب التقاطع"),
         ("Remove wallpaper during incoming sessions", "إزالة الخلفية أثناء الجلسات الواردة"),

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Аўтаматычна зачыняць уваходныя сеансы пры неактыўнасці карыстальніка"),
         ("Connection failed due to inactivity", "Падлучэнне не ўдалося з-за неактыўнасці"),
         ("Check for software update on startup", "Праверка абнаўленняў праграмы пры запуску"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Абнавіце VNFap Server да версіі {} або новейшай!"),
         ("pull_group_failed_tip", "Немагчыма абнавіць групу"),
         ("Filter by intersection", "Фільтраваць па перасячэнні"),
         ("Remove wallpaper during incoming sessions", "Схаваць фон працоўнага стала падчас ўваходнага сеансу"),

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Автоматично затваряне на входящите сесии при неактивност на потребителя"),
         ("Connection failed due to inactivity", "Автоматично прекъсване на връзката поради неактивност"),
         ("Check for software update on startup", "Проверявай за обновления при стартиране"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Моля обновете VNFap Server на версия {} или по-нова!"),
         ("pull_group_failed_tip", "Неуспешно опресняване на групата"),
         ("Filter by intersection", "Отсяване по пресичане"),
         ("Remove wallpaper during incoming sessions", "Спри фоновото изображение по време на входящи сесии"),

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Tanca automàticament les sessions entrants per inactivitat de l'usuari"),
         ("Connection failed due to inactivity", "Ha fallat la connexió per inactivitat"),
         ("Check for software update on startup", "Cerca actualitzacions en iniciar"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Actualitzeu el VNFap Server a la versió {} o superior!"),
         ("pull_group_failed_tip", "Ha fallat en actualitzar el grup"),
         ("Filter by intersection", "Filtra per intersecció"),
         ("Remove wallpaper during incoming sessions", "Inhabilita el fons d'escriptori durant la sessió entrant"),

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "自动关闭不活跃的会话"),
         ("Connection failed due to inactivity", "由于长时间无操作, 连接被自动断开"),
         ("Check for software update on startup", "启动时检查软件更新"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "请升级专业版服务器到{}或更高版本！"),
         ("pull_group_failed_tip", "获取组信息失败"),
         ("Filter by intersection", "按交集过滤"),
         ("Remove wallpaper during incoming sessions", "接受会话时移除桌面壁纸"),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Automatické ukončení příchozích relací při nečinnosti uživatele"),
         ("Connection failed due to inactivity", "Připojení se nezdařilo z důvodu nečinnosti"),
         ("Check for software update on startup", "Kontrola aktualizace softwaru při spuštění"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Aktualizujte prosím VNFap Server na verzi {} nebo novější!"),
         ("pull_group_failed_tip", "Nepodařilo se obnovit skupinu"),
         ("Filter by intersection", "Filtrovat podle průsečíku"),
         ("Remove wallpaper during incoming sessions", "Odstranit tapetu během příchozích relací"),

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Luk automatisk indkommende sessioner ved inaktivitet"),
         ("Connection failed due to inactivity", "Forbindelsen blev afbrudt grundet inaktivitet"),
         ("Check for software update on startup", "Søg efter opdateringer ved opstart"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Opgradér venligst VNFap Server til version {} eller nyere!"),
         ("pull_group_failed_tip", "Genindlæsning af gruppe mislykkedes"),
         ("Filter by intersection", "Filtrér efter intersection"),
         ("Remove wallpaper during incoming sessions", "Skjul baggrundsskærm ved indgående forbindelser"),

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Eingehende Sitzungen bei Benutzer-Inaktivität automatisch schließen"),
         ("Connection failed due to inactivity", "Automatische Trennung der Verbindung aufgrund von Inaktivität"),
         ("Check for software update on startup", "Beim Start auf Softwareaktualisierung prüfen"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Bitte aktualisieren Sie VNFap Server auf die Version {} oder neuer!"),
         ("pull_group_failed_tip", "Aktualisierung der Gruppe fehlgeschlagen"),
         ("Filter by intersection", "Nach Schnittmenge filtern"),
         ("Remove wallpaper during incoming sessions", "Hintergrundbild bei eingehenden Sitzungen entfernen"),

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Αυτόματη αποσύνδεση απομακρυσμένης συνεδρίας έπειτα από την πάροδο του χρονικού ορίου αδράνειας "),
         ("Connection failed due to inactivity", "Η σύνδεση τερματίστηκε έπειτα από την πάροδο του χρόνου αδράνειας"),
         ("Check for software update on startup", "Έλεγχος για ενημερώσεις κατα την εκκίνηση"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Παρακαλώ ενημερώστε τον VNFap Server στην έκδοση {} ή νεότερη!"),
         ("pull_group_failed_tip", "Αποτυχία ανανέωσης της ομάδας"),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", "Αφαίρεση εικόνας φόντου στις εισερχόμενες συνδέσεις"),

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -194,7 +194,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("scam_text2", "They are likely a scammer trying to steal your money or other private information."),
         ("auto_disconnect_option_tip", "Automatically close incoming sessions on user inactivity"),
         ("Connection failed due to inactivity", "Automatically disconnected due to inactivity"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Please upgrade VNFap Server to version {} or newer!"),
         ("pull_group_failed_tip", "Failed to refresh group"),
         ("doc_fix_wayland", "https://vnfap.com/docs/en/client/linux/#x11-required"),
         ("display_is_plugged_out_msg", "The display is plugged out, switch to the first display."),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Cerrar sesiones entrantes automáticamente por inactividad del usuario."),
         ("Connection failed due to inactivity", "Desconectar automáticamente por inactividad."),
         ("Check for software update on startup", "Comprobar actualización al iniciar"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "¡Por favor, actualiza VNFap Server a la versión {} o superior"),
         ("pull_group_failed_tip", "No se ha podido refrescar el grupo"),
         ("Filter by intersection", "Filtrar por intersección"),
         ("Remove wallpaper during incoming sessions", "Quitar el fondo de pantalla durante sesiones entrantes"),

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Sissetulevate seansside automaatne sulgemine kasutaja mitteaktiivsuse korral"),
         ("Connection failed due to inactivity", "Mitteaktiivsuse tõttu automaatselt lahti ühendatud"),
         ("Check for software update on startup", "Kontrolli käivitusel tarkvarauuendust"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Palun täienda VNFap Server versioonile {} või uuem!"),
         ("pull_group_failed_tip", "Grupi värskendamine ebaõnnestus"),
         ("Filter by intersection", "Filtreeri ristumiste järgi"),
         ("Remove wallpaper during incoming sessions", "Eemalda taustapilt sissetulevate seansside ajal"),

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Itxi sarrerako konexioak automatikoki erabiltzailearen jarduera faltagatik."),
         ("Connection failed due to inactivity", "Konexioak huts egin du jarduera faltagatik"),
         ("Check for software update on startup", "Egiaztatu software eguneraketak abiatzerakoan"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Mesedez, bertsio-berritu VNFap Server {} bertsiora edo berriago batera!"),
         ("pull_group_failed_tip", "Ezin izan da taldea freskatu"),
         ("Filter by intersection", "Iragazi bidegurutzez"),
         ("Remove wallpaper during incoming sessions", "Kendu horma-papera sarrerako saioetan"),

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "بسته شدن خودکار جلسات ورودی در صورت عدم فعالیت کاربر"),
         ("Connection failed due to inactivity", "اتصال به دلیل عدم فعالیت بسته شد"),
         ("Check for software update on startup", "در هنگلم شروع برنامه بروزرسانی را بررسی کن"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "را به نسخه {} یا جدیدتر ارتقا دهید VNFap Server لظفا"),
         ("pull_group_failed_tip", "گروه بازخوانی نشد"),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", "را در جلسات ورودی حذف کنید Wallpaper"),

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Terminer automatiquement les sessions entrantes en cas d’inactivité de l’utilisateur"),
         ("Connection failed due to inactivity", "Déconnecté automatiquement pour cause d’inactivité"),
         ("Check for software update on startup", "Vérifier la disponibilité des mises à jour au démarrage"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Veuillez mettre à jour VNFap Server vers la version {} ou une version ultérieure !"),
         ("pull_group_failed_tip", "Échec de l’actualisation du groupe"),
         ("Filter by intersection", "Filtrer par intersection"),
         ("Remove wallpaper during incoming sessions", "Cacher le fond d’écran lors des sessions entrantes"),

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "ავტომატურად დახუროს შემომავალი სესიები მომხმარებლის არააქტიურობისას"),
         ("Connection failed due to inactivity", "კავშირი ვერ განხორციელდა არააქტიურობის გამო"),
         ("Check for software update on startup", "პროგრამის განახლების შემოწმება გაშვებისას"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "განაახლეთ VNFap Server ვერსიამდე {} ან უფრო ახალი!"),
         ("pull_group_failed_tip", "ჯგუფის განახლება შეუძლებელია"),
         ("Filter by intersection", "ფილტრაცია გადაკვეთით"),
         ("Remove wallpaper during incoming sessions", "სამუშაო მაგიდის ფონის დამალვა შემომავალი სესიის დროს"),

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "סגור באופן אוטומטי הפעלות נכנסות במקרה של חוסר פעילות של המשתמש"),
         ("Connection failed due to inactivity", "התנתקות אוטומטית בגלל חוסר פעילות"),
         ("Check for software update on startup", "בדוק עדכונים עם ההפעלה"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "אנא שדרג את VNFap Server לגרסה {} או חדשה יותר!"),
         ("pull_group_failed_tip", "נכשל ברענון הקבוצה"),
         ("Filter by intersection", "סנן לפי חיתוך"),
         ("Remove wallpaper during incoming sessions", "הסר רקע שולחן עבודה במהלך הפעלות נכנסות"),

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Automatsko prekidanje dolaznih veza kada je korisnik neaktivan"),
         ("Connection failed due to inactivity", "Povezivanje nije uspjelo zbog neaktivnosti"),
         ("Check for software update on startup", "Provjera ažuriranja softvera pri pokretanju"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Ažurirajte VNFap Server na verziju {} ili noviju!"),
         ("pull_group_failed_tip", "Vraćanje grupe nije uspjelo"),
         ("Filter by intersection", "Filtriraj po prosjeku"),
         ("Remove wallpaper during incoming sessions", "Uklonite pozadinu tijekom dolaznih sesija"),

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "A bejövő munkamenetek automatikus bezárása, ha a felhasználó inaktív"),
         ("Connection failed due to inactivity", "A kapcsolat inaktivitás miatt megszakadt"),
         ("Check for software update on startup", "Szoftverfrissítés keresése indításkor"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Frissítse a VNFap Servert a(z) {} vagy újabb verzióra!"),
         ("pull_group_failed_tip", "A csoport frissítése nem sikerült"),
         ("Filter by intersection", "Szűrés metszéspontok szerint"),
         ("Remove wallpaper during incoming sessions", "Távolítsa el a háttérképet a bejövő munkamenetek közben"),

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Secara otomatis akan menutup sesi ketika tidak ada aktivitas"),
         ("Connection failed due to inactivity", "Secara otomatis akan terputus ketik tidak ada aktivitas."),
         ("Check for software update on startup", "Periksa pembaruan aplikasi saat sistem dinyalakan."),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Silahkan perbarui VNFap Server ke versi {} atau yang lebih baru!"),
         ("pull_group_failed_tip", "Gagal memperbarui grup"),
         ("Filter by intersection", "Filter berdasarkan persilangan"),
         ("Remove wallpaper during incoming sessions", "Hilangkan latar dinding ketika ada sesi yang masuk"),

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Chiudi automaticamente sessioni in entrata per inattività utente"),
         ("Connection failed due to inactivity", "Connessione non riuscita a causa di inattività"),
         ("Check for software update on startup", "All'avvio verifica presenza aggiornamenti programma"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Aggiorna VNFap Server alla versione {} o successiva!"),
         ("pull_group_failed_tip", "Impossibile aggiornare il gruppo"),
         ("Filter by intersection", "Filtra per incrocio"),
         ("Remove wallpaper during incoming sessions", "Rimuovi sfondo durante sessioni in entrata"),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "ユーザーが非アクティブの場合、自動的に受信したセッションを閉じる"),
         ("Connection failed due to inactivity", "リモートデスクトップ ユーザーが非アクティブなため、接続に失敗しました"),
         ("Check for software update on startup", "起動時にソフトウェアの更新をチェック"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "VNFap Serverをバージョン{}以上にアップグレードしてください！"),
         ("pull_group_failed_tip", "グループの更新に失敗しました"),
         ("Filter by intersection", "交差位置でフィルター"),
         ("Remove wallpaper during incoming sessions", "セッションの受信中、デスクトップ背景を削除する"),

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "비활성 시 연결 자동 종료"),
         ("Connection failed due to inactivity", "장시간 활동이 없어 연결이 자동으로 종료되었습니다"),
         ("Check for software update on startup", "시작 시 소프트웨어 업데이트 확인"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "VNFap Server를 {} 버전 이상으로 업그레이드하세요!"),
         ("pull_group_failed_tip", "그룹 정보를 가져오지 못했습니다"),
         ("Filter by intersection", "교집합으로 필터링"),
         ("Remove wallpaper during incoming sessions", "연결 수락 시 배경화면 제거"),

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Automātiski aizvērt ienākošās sesijas lietotāja neaktivitātes gadījumā"),
         ("Connection failed due to inactivity", "Automātiski atvienots neaktivitātes dēļ"),
         ("Check for software update on startup", "Startējot pārbaudīt, vai nav programmatūras atjauninājumu"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Lūdzu, jauniniet VNFap Server uz versiju {} vai jaunāku!"),
         ("pull_group_failed_tip", "Neizdevās atsvaidzināt grupu"),
         ("Filter by intersection", "Filtrēt pēc krustpunkta"),
         ("Remove wallpaper during incoming sessions", "Noņemt fona tapeti ienākošo sesiju laikā"),

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Inkomende sessies automatisch sluiten bij inactiviteit van de gebruiker"),
         ("Connection failed due to inactivity", "Automatisch verbinding verbroken wegens inactiviteit"),
         ("Check for software update on startup", "Controleer op updates bij opstarten"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Upgrade VNFap Server naar versie {} of nieuwer!"),
         ("pull_group_failed_tip", "Vernieuwen van groep mislukt"),
         ("Filter by intersection", "Filter op kruising"),
         ("Remove wallpaper during incoming sessions", "Achtergrond verwijderen tijdens inkomende sessies"),

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Automatycznie rozłącz sesje przychodzące przy braku aktywności użytkownika"),
         ("Connection failed due to inactivity", "Automatycznie rozłącz przy bezczynności"),
         ("Check for software update on startup", "Sprawdź aktualizacje przy starcie programu"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Proszę zaktualizować VNFap Server do wersji {} lub nowszej!"),
         ("pull_group_failed_tip", "Błąd odświeżania grup"),
         ("Filter by intersection", "Filtruj wg przecięcia"),
         ("Remove wallpaper during incoming sessions", "Usuń tapetę podczas sesji przychodzących"),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Encerrar sessões entrantes automaticamente por inatividade do usuário."),
         ("Connection failed due to inactivity", "Conexão encerrada automaticamente por inatividade."),
         ("Check for software update on startup", "Verificar atualizações do software ao iniciar"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Atualize o VNFap Server para a versão {} ou superior."),
         ("pull_group_failed_tip", "Não foi possível atualizar o grupo."),
         ("Filter by intersection", "Filtrar por interseção"),
         ("Remove wallpaper during incoming sessions", "Remover papel de parede durante sessão remota"),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Автоматически закрывать входящие сеансы при неактивности пользователя"),
         ("Connection failed due to inactivity", "Подключение не выполнено из-за неактивности"),
         ("Check for software update on startup", "Проверять обновления программы при запуске"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Обновите VNFap Server до версии {} или новее!"),
         ("pull_group_failed_tip", "Невозможно обновить группу"),
         ("Filter by intersection", "Фильтровать по пересечению"),
         ("Remove wallpaper during incoming sessions", "Скрывать обои рабочего стола при входящем сеансе"),

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Serra in automàticu sas sessiones in intrada pro inatividade de s'utente"),
         ("Connection failed due to inactivity", "Connessione non resèssida pro neghe de inatividade"),
         ("Check for software update on startup", "A s'allughìngiu avèrgua sa presèntzia de atualizatziones pro su programma"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Atualiza VNFap Server a sa versione {} o prus noa!"),
         ("pull_group_failed_tip", "Non faghet a annoare su grupu"),
         ("Filter by intersection", "Filtra pro rugrada"),
         ("Remove wallpaper during incoming sessions", "Boga s'isfundu durante sas sessiones in intrada"),

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Automatické ukončenie prichádzajúcich relácií, keď je používateľ nečinný"),
         ("Connection failed due to inactivity", "Pripojenie zlyhalo z dôvodu nečinnosti"),
         ("Check for software update on startup", "Kontrola aktualizácií softvéru pri spustení"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Aktualizujte VNFap Server na verziu {} alebo novšiu!"),
         ("pull_group_failed_tip", "Nepodarilo sa obnoviť skupinu"),
         ("Filter by intersection", "Filtrovať podľa križovatky"),
         ("Remove wallpaper during incoming sessions", "Odstrániť tapetu počas prichádzajúcich relácií"),

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Samodejno prekini neaktivne seje"),
         ("Connection failed due to inactivity", "Povezava je bila prekinjena zaradi neaktivnosti"),
         ("Check for software update on startup", "Preveri za posodobitve ob zagonu"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Prosimo, nadgradite VNFap Server na različico {} ali novejšo."),
         ("pull_group_failed_tip", "Osveževanje skupine ni uspelo"),
         ("Filter by intersection", "Filtriraj po preseku"),
         ("Remove wallpaper during incoming sessions", "Odstrani sliko ozadja ob dohodnih povezavah"),

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "ยกเลิกการเชื่อมต่ออัตโนมัติในกรณีที่ผู้ใช้งานไม่มีการเคลื่อนไหว"),
         ("Connection failed due to inactivity", "การเชื่อมต่อล้มเหลวเนื่องจากไม่มีการเคลื่อนไหว"),
         ("Check for software update on startup", "ตรวจสอบการอัปเดตโปรแกรมเมื่อเริ่มต้นใช้งาน"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "กรุณาอัปเดต VNFap Server ไปยังเวอร์ชัน {} หรือใหม่กว่า!"),
         ("pull_group_failed_tip", "การเรียกใช้งานกลุ่มล้มเหลว"),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "自動在連入的使用者不活躍時關閉工作階段"),
         ("Connection failed due to inactivity", "由於長時間沒有操作，已自動關閉工作階段"),
         ("Check for software update on startup", "啟動時檢查更新"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "請升級專業版伺服器到{}或更高版本！"),
         ("pull_group_failed_tip", "獲取群組訊息失敗"),
         ("Filter by intersection", "按照交集篩選"),
         ("Remove wallpaper during incoming sessions", "在接受連入連線時移除桌布"),

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", "Автоматично завершувати вхідні сеанси в разі неактивності користувача"),
         ("Connection failed due to inactivity", "Зʼєднання розірвано через неактивність"),
         ("Check for software update on startup", "Перевіряти оновлення під час запуску"),
-        ("upgrade_vnfap_server_pro_to_{}_tip", "Будь ласка, оновіть VNFap Server до версії {} чи новіше!"),
         ("pull_group_failed_tip", "Не вдалося оновити групу"),
         ("Filter by intersection", "Фільтр за збігом"),
         ("Remove wallpaper during incoming sessions", "Прибирати шпалеру під час вхідних сеансів"),

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -545,7 +545,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("auto_disconnect_option_tip", ""),
         ("Connection failed due to inactivity", ""),
         ("Check for software update on startup", ""),
-        ("upgrade_vnfap_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
         ("Filter by intersection", ""),
         ("Remove wallpaper during incoming sessions", ""),

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -1374,7 +1374,7 @@ function refreshCurrentUser() {
             return;
         }
 	if (!handler.verify_login(data.verifier, token)) {
-          handleAbError("Please update your self-hosting server Pro to latest version");
+          handleAbError("Please update your self-hosting server to the latest version");
           return;
         }
         set_local_user_info(data);


### PR DESCRIPTION
## Summary
- clean translations of 'server pro' upgrade prompts
- update message about self-hosting server version

## Testing
- `cargo test --workspace --quiet` *(fails: failed to load manifest for workspace member)*

------
https://chatgpt.com/codex/tasks/task_e_684a59802ae48320835e34109c54f871