### PR TITLE
Refactor clipboard file check

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -76,7 +76,7 @@ pub fn check_clipboard(
 }
 
 #[cfg(all(feature = "unix-file-copy-paste", target_os = "macos"))]
-pub fn is_file_url_set_by_vnfap(url: &Vec<String>) -> bool {
+pub fn is_file_url_set_by_vnfap(url: &[String]) -> bool {
     if url.len() != 1 {
         return false;
     }


### PR DESCRIPTION
## Summary
- accept slice instead of `&Vec<String>` in clipboard URL check

## Testing
- `cargo test --locked` *(fails: failed to load manifest for workspace member)*

------
https://chatgpt.com/codex/tasks/task_e_684a5d4c43f88320b51a3655f3daad78